### PR TITLE
use litellm for API calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Environment variables
+.env
+
+# Python cache files
+__pycache__/
+*.py[cod]
+
+# Generated spreadsheets
+DV_*.xlsx
+

--- a/pythonProject/.env.example
+++ b/pythonProject/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to `.env` and fill in your API key.
+# The `.env` file will not be committed to version control.
+
+LITELLM_API_KEY=sk-your_api_key_here
+

--- a/pythonProject/test.py
+++ b/pythonProject/test.py
@@ -14,6 +14,7 @@ single social‑sensitivity value.
 """
 
 from litellm import completion
+import os
 import pandas as pd
 import openpyxl
 import random
@@ -21,8 +22,28 @@ import time
 from datetime import datetime
 from pathlib import Path
 
-# Set API key
-api_key = "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"
+
+def load_env():
+    """Load environment variables from a .env file if present."""
+    env_path = Path(__file__).resolve().parent / ".env"
+    if env_path.exists():
+        with env_path.open() as file:
+            for line in file:
+                line = line.strip()
+                if line and not line.startswith("#") and "=" in line:
+                    key, value = line.split("=", 1)
+                    os.environ.setdefault(key, value)
+
+
+# Load .env variables and read the API key
+load_env()
+api_key = os.getenv("LITELLM_API_KEY")
+if not api_key:
+    raise RuntimeError("LITELLM_API_KEY not set. Create a .env file or export the variable before running.")
+
+# To switch providers, set their API key in the environment and supply the
+# provider-prefixed model name (e.g., "anthropic/claude-3-haiku") when calling
+# ``completion`` below.
 
 # Function to generate random participant details
 def generate_participant_details():


### PR DESCRIPTION
## Summary
- replace OpenAI SDK usage with liteLLM completion calls
- fix random social-sensitivity selection and file path handling

## Testing
- `python pythonProject/test.py` *(fails: litellm.AuthenticationError: incorrect API key)*

------
https://chatgpt.com/codex/tasks/task_e_689095fa6c648330b55eb923291a993f