### PR TITLE
feat: support image conditions and customizable traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
    export LITELLM_API_KEY=sk-xxxx
    ```
 3. **准备实验条件**
-   修改 `pythonProject/conditionA.txt` 与 `pythonProject/conditionB.txt` 以适配你的实验设计；文本内容会作为对被试的提示词。
+   `pythonProject/conditionA.txt` 与 `pythonProject/conditionB.txt` 可以是文本或图片
+   （如 `.png`、`.jpg`），其内容将作为对被试的提示材料。
 
 ## 运行模拟
 从仓库根目录执行：
@@ -39,16 +40,17 @@ python pythonProject/simulate.py --participants 50 --model gpt-4o-mini
 - `-n / --participants`：生成的被试数量，默认 200。
 - `-m / --model`：`litellm` 识别的模型名称，默认 `gpt-4o-mini`。
 - `-o / --output`：结果 Excel 文件的保存路径，默认使用时间戳命名并写在当前目录。
+- `--profile-config`：可选的 JSON 文件，定义人口统计信息候选值以及需要随机的特质名称（特质默认按 1–7 计分）。
 
 ## 运行流程解析
 `simulate.py` 的核心逻辑位于 `simulate_participants` 函数，其执行步骤如下：
-1. 读取 `.env` 获取 `LITELLM_API_KEY`，并加载实验条件文本。
+1. 读取 `.env` 获取 `LITELLM_API_KEY`，并加载实验条件文本或图片。
 2. 针对每个被试：
-   - 随机选择 A 或 B 条件，并生成年龄、性别、文化背景、社交敏感度、情绪等人口统计信息。
-   - 调用 `build_messages` 构造发送给模型的多轮对话消息，其中系统角色描述被试的身份信息，后续用户消息给出实验提示。
+   - 随机选择 A 或 B 条件，并按配置生成年龄、性别、文化背景等人口统计信息，以及若干 1–7 计分的个体特质（如 Big Five）。
+   - 调用 `build_messages` 构造发送给模型的多轮对话消息，其中系统角色描述被试的身份信息和特质含义，后续用户消息给出实验提示。
    - 使用 `litellm.completion` 向指定模型请求回答，随机设置 `temperature` 与 `top_p` 以增加多样性。
    - 将模型输出作为因变量（`DV`）并连同元数据一起存储。
-3. 所有被试完成后，将结果写入 Excel，文件包含列：`Age`、`Sex`、`Culture Background`、`Social Sensitivity`、`Mood`、`Condition` 与 `DV`。
+3. 所有被试完成后，将结果写入 Excel，文件包含人口统计信息、各项特质、实验条件与因变量（`DV`）。
 
 ## 示例
 ```bash
@@ -58,8 +60,8 @@ python pythonProject/simulate.py -n 2 -m gpt-4o-mini -o demo.xlsx
 运行后终端会输出结果文件路径，例如 `demo.xlsx`，其中包含 2 行被试的模拟数据。
 
 ## 自定义与扩展
-- **新增实验条件**：可在 `pythonProject` 目录中创建更多条件文件，并在脚本中加载。
-- **替换人口统计信息生成规则**：编辑 `generate_participant_details` 函数，自定义年龄范围或其他属性列表。
+- **新增实验条件**：可在 `pythonProject` 目录中创建更多文本或图片条件文件，并在脚本中加载。
+- **自定义人口统计与特质**：通过 `--profile-config` 提供 JSON 配置或编辑 `generate_participant_details` 函数，控制年龄范围、性别列表以及要随机的特质。
 - **更换模型或参数**：通过命令行参数选择模型，或修改 `simulate_participants` 内的 `temperature`、`top_p` 范围以调整生成风格。
 
 ## 许可协议
@@ -88,8 +90,9 @@ file automatically.
 
 3. **Edit experimental conditions**
 
-   The prompts presented to the simulated participants live in
+   The materials presented to the simulated participants live in
    `pythonProject/conditionA.txt` and `pythonProject/conditionB.txt`.
+   Each file can be plain text or an image such as `.png` or `.jpg`.
    Adjust them to match your experiment.
 
 ## Usage
@@ -105,7 +108,9 @@ Command‑line options:
 - `--participants` / `-n` – number of synthetic participants (default 200).
 - `--model` / `-m` – model name understood by `litellm`.
 - `--output` / `-o` – optional path to save the Excel file (default uses a
-timestamped name).
+  timestamped name).
+- `--profile-config` – optional JSON file describing demographic choices and
+  trait names to sample (traits use a 1–7 scale).
 
 The script saves an Excel spreadsheet containing the condition, model
-output, and generated participant metadata.
+output, and generated participant metadata including all sampled traits.

--- a/pythonProject/simulate.py
+++ b/pythonProject/simulate.py
@@ -9,6 +9,8 @@ parameters are configurable.
 from __future__ import annotations
 
 import argparse
+import base64
+import json
 import os
 import random
 import time
@@ -26,65 +28,101 @@ from litellm import completion
 BASE_DIR = Path(__file__).resolve().parent
 
 
-def generate_participant_details() -> tuple[int, str, str, str, str]:
-    """Return random demographic information for a synthetic participant."""
-    age = random.randint(18, 65)
-    sex = random.choice(["male", "female"])
+def load_profile_config(path: Path | None) -> tuple[dict, list[str] | None]:
+    """Load optional profile configuration from JSON."""
+    if path is None:
+        return {}, None
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    demographics = data.get("demographics", {})
+    traits = data.get("characteristics")
+    return demographics, traits
+
+
+def generate_participant_details(
+    demographics_options: dict | None = None,
+    traits: list[str] | None = None,
+) -> tuple[dict, dict]:
+    """Return random demographic and trait information."""
+
+    demographics_options = demographics_options or {}
+    age_range = demographics_options.get("age_range", (18, 65))
+    age = random.randint(*age_range)
+    sex = random.choice(demographics_options.get("sex", ["male", "female"]))
     culture_background = random.choice(
-        [
-            "Caucasian",
-            "African",
-            "Asian",
-            "Latino",
-            "Middle Eastern",
-            "Indigenous",
-            "Mixed",
-        ]
+        demographics_options.get(
+            "culture_background",
+            [
+                "Caucasian",
+                "African",
+                "Asian",
+                "Latino",
+                "Middle Eastern",
+                "Indigenous",
+                "Mixed",
+            ],
+        )
     )
-    social_sensitivity = random.choice(
-        ["very low", "low", "moderate", "high", "very high"]
-    )
-    mood = random.choice(
-        [
-            "happy",
-            "sad",
-            "angry",
-            "anxious",
-            "excited",
-            "calm",
-            "bored",
-            "confused",
-            "frustrated",
-            "hopeful",
-            "relaxed",
-            "nervous",
-            "grateful",
-            "jealous",
-            "content",
-        ]
-    )
-    return age, sex, culture_background, social_sensitivity, mood
+
+    demographics = {
+        "Age": age,
+        "Sex": sex,
+        "Culture Background": culture_background,
+    }
+
+    traits = traits or [
+        "extraversion",
+        "agreeableness",
+        "conscientiousness",
+        "neuroticism",
+        "openness",
+    ]
+    characteristics = {trait: random.randint(1, 7) for trait in traits}
+    return demographics, characteristics
 
 
-def load_condition(file_path: Path) -> str:
-    """Return the contents of a text file used as an experimental condition."""
-    with file_path.open("r", encoding="utf-8") as fh:
-        return fh.read().strip()
+def load_condition(file_path: Path) -> list[dict]:
+    """Return message parts for a condition, supporting text and images."""
+
+    suffix = file_path.suffix.lower()
+    if suffix == ".txt":
+        text = file_path.read_text(encoding="utf-8").strip()
+        return [{"type": "text", "text": text}]
+    if suffix in {".png", ".jpg", ".jpeg", ".gif"}:
+        with file_path.open("rb") as fh:
+            b64 = base64.b64encode(fh.read()).decode("ascii")
+        mime = "jpeg" if suffix in {".jpg", ".jpeg"} else suffix.lstrip(".")
+        url = f"data:image/{mime};base64,{b64}"
+        return [{"type": "image_url", "image_url": {"url": url}}]
+    raise ValueError(f"Unsupported condition file type: {file_path}")
 
 
-def build_messages(condition_text: str) -> tuple[list[dict], dict]:
+def build_messages(
+    condition_content: list[dict],
+    demographics_options: dict | None = None,
+    traits: list[str] | None = None,
+) -> tuple[list[dict], dict]:
     """Create messages for the language model and participant metadata."""
-    age, sex, culture_background, social_sensitivity, mood = (
-        generate_participant_details()
+
+    demographics, characteristics = generate_participant_details(
+        demographics_options, traits
     )
     system_prompt = (
-        "You are a human living in the US. You are {} years old, {} gender, "
-        "with {} cultural background. You social sensitivity is {}. Today you are "
-        "feeling {}."
-    ).format(age, sex, culture_background, social_sensitivity, mood)
+        "You are a human living in the US. You are {age} years old, {sex} gender, "
+        "with {culture} cultural background.".format(
+            age=demographics["Age"],
+            sex=demographics["Sex"],
+            culture=demographics["Culture Background"],
+        )
+    )
+    for trait, value in characteristics.items():
+        system_prompt += (
+            f" Your {trait} is {value} (1=very low, 7=very high)."
+        )
+
     messages = [
         {"role": "system", "content": system_prompt},
-        {"role": "user", "content": condition_text},
+        {"role": "user", "content": condition_content},
         {"role": "user", "content": "Think carefully about what kind of person you are."},
         {
             "role": "user",
@@ -94,13 +132,7 @@ def build_messages(condition_text: str) -> tuple[list[dict], dict]:
             ),
         },
     ]
-    metadata = {
-        "Age": age,
-        "Sex": sex,
-        "Culture Background": culture_background,
-        "Social Sensitivity": social_sensitivity,
-        "Mood": mood,
-    }
+    metadata = {**demographics, **{trait.title(): val for trait, val in characteristics.items()}}
     return messages, metadata
 
 
@@ -113,6 +145,7 @@ def simulate_participants(
     count: int,
     model: str,
     output: Path | None = None,
+    profile_config: Path | None = None,
 ) -> Path:
     """Run the simulation and save results to an Excel file.
 
@@ -125,6 +158,8 @@ def simulate_participants(
     output:
         Optional path to the Excel file.  If omitted, a timestamped file is
         created in the current directory.
+    profile_config:
+        Optional JSON file describing demographic choices and trait names.
     Returns
     -------
     Path
@@ -138,6 +173,8 @@ def simulate_participants(
             "LITELLM_API_KEY not set. Create a .env file or export the variable before running."
         )
 
+    demo_options, trait_names = load_profile_config(profile_config)
+
     condition_a = load_condition(BASE_DIR / "conditionA.txt")
     condition_b = load_condition(BASE_DIR / "conditionB.txt")
 
@@ -145,8 +182,12 @@ def simulate_participants(
     for i in range(count):
         try:
             condition_key = random.choice(["condition A", "condition B"])
-            condition_text = condition_a if condition_key == "condition A" else condition_b
-            messages, metadata = build_messages(condition_text)
+            condition_content = (
+                condition_a if condition_key == "condition A" else condition_b
+            )
+            messages, metadata = build_messages(
+                condition_content, demo_options, trait_names
+            )
 
             response = completion(
                 model=model,
@@ -197,12 +238,19 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="optional path to save the Excel results",
     )
+    parser.add_argument(
+        "--profile-config",
+        type=Path,
+        help="JSON file with demographic options and trait names",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    path = simulate_participants(args.participants, args.model, args.output)
+    path = simulate_participants(
+        args.participants, args.model, args.output, args.profile_config
+    )
     print(f"Results saved to {path}")
 
 


### PR DESCRIPTION
## Summary
- handle experiment conditions as text or images
- generate participant traits on a 1–7 scale and include meanings in prompts
- allow JSON-driven customization of demographics and trait names

## Testing
- `python -m py_compile pythonProject/simulate.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a0e10fbc8330b3f07b2ed08fe83b