### PR TITLE
feat: support image conditions and customizable traits

### DIFF
--- a/pythonProject/profile_config.example.json
+++ b/pythonProject/profile_config.example.json
@@ -1,0 +1,22 @@
+{
+  "demographics": {
+    "age_range": [18, 65],
+    "sex": ["male", "female"],
+    "culture_background": [
+      "Caucasian",
+      "African",
+      "Asian",
+      "Latino",
+      "Middle Eastern",
+      "Indigenous",
+      "Mixed"
+    ]
+  },
+  "characteristics": {
+    "extraversion": "1=very introverted, 7=very extraverted",
+    "agreeableness": "1=very disagreeable, 7=very agreeable",
+    "conscientiousness": "1=very disorganized, 7=very organized",
+    "neuroticism": "1=very calm, 7=very anxious",
+    "openness": "1=very traditional, 7=very open-minded"
+  }
+}


### PR DESCRIPTION
## Summary
- centralize demographic and trait customization in `profile_config.json` with scale descriptions
- automatically load profile config and include trait meanings in system prompts
- document profile config workflow and add example file

## Testing
- `python -m py_compile pythonProject/simulate.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a0e10fbc8330b3f07b2ed08fe83b