### PR TITLE
Add vendor/model dropdowns to simulator GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@
    cp pythonProject/profile_config.example.json pythonProject/profile_config.json
    # 编辑 profile_config.json 以调整人口统计选项及特质含义
    ```
-   
+
+## 图形界面
+运行简单图形界面：
+```bash
+python pythonProject/gui.py
+```
+在窗口中填写参与者数量，通过下拉列表选择模型供应商和模型名称，还可设置输出路径和配置文件，最后点击“Start Simulation”即可。
+
 ## 运行模拟
 从仓库根目录执行：
 ```bash
@@ -120,6 +127,14 @@ Run the simulator from the repository root:
 python pythonProject/simulate.py --participants 50 --model gpt-4o-mini
 ```
 
+There is also a minimal GUI:
+
+```bash
+python pythonProject/gui.py
+```
+
+The window lets you enter the number of participants and pick a model provider and model name from drop‑down lists, plus optional output and profile configuration paths.
+
 Command‑line options:
 
 - `--participants` / `-n` – number of synthetic participants (default 200).
@@ -128,9 +143,6 @@ Command‑line options:
   timestamped name).
 - `--profile-config` – JSON file listing demographic choices and trait scale
   descriptions (defaults to `pythonProject/profile_config.json`).
-=======
-- `--profile-config` – optional JSON file describing demographic choices and
-  trait names to sample (traits use a 1–7 scale).
 
 The script saves an Excel spreadsheet containing the condition, model
 output, and generated participant metadata including all sampled traits.

--- a/pythonProject/gui.py
+++ b/pythonProject/gui.py
@@ -1,0 +1,158 @@
+"""Simple Tkinter GUI for the participant simulator.
+
+This interface wraps :func:`simulate_participants` so that non-technical
+users can run the experiment generation without touching the command line.
+"""
+
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+from simulate import simulate_participants
+
+
+MODEL_CATALOG = {
+    "openai": ["gpt-4o-mini", "gpt-4o", "gpt-4.1"],
+    "anthropic": ["claude-3-haiku-20240307", "claude-3-sonnet-20240229"],
+    "google": ["gemini-1.5-flash", "gemini-1.5-pro"],
+}
+
+
+class SimulatorGUI(tk.Tk):
+    """Main application window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.title("GPT Participants Simulator")
+        self.resizable(False, False)
+
+        # Variables
+        self.participants_var = tk.StringVar(value="200")
+        self.vendor_var = tk.StringVar(value="openai")
+        self.model_var = tk.StringVar(value=MODEL_CATALOG["openai"][0])
+        self.output_var = tk.StringVar()
+        default_profile = Path(__file__).parent / "profile_config.json"
+        self.profile_var = tk.StringVar(
+            value=str(default_profile) if default_profile.exists() else ""
+        )
+        self.status_var = tk.StringVar(value="Ready")
+
+        self._build_widgets()
+
+    # ------------------------------------------------------------------
+    def _build_widgets(self) -> None:
+        padding = {"padx": 5, "pady": 5}
+
+        frm = ttk.Frame(self)
+        frm.grid(row=0, column=0, sticky="nsew")
+
+        ttk.Label(frm, text="Participants:").grid(row=0, column=0, **padding, sticky="e")
+        ttk.Entry(frm, textvariable=self.participants_var, width=10).grid(
+            row=0, column=1, **padding
+        )
+
+        ttk.Label(frm, text="Vendor:").grid(row=1, column=0, **padding, sticky="e")
+        vendor_box = ttk.Combobox(
+            frm, textvariable=self.vendor_var, values=list(MODEL_CATALOG), state="readonly"
+        )
+        vendor_box.grid(row=1, column=1, **padding)
+        vendor_box.bind("<<ComboboxSelected>>", self._on_vendor_change)
+
+        ttk.Label(frm, text="Model:").grid(row=2, column=0, **padding, sticky="e")
+        self.model_box = ttk.Combobox(frm, textvariable=self.model_var, state="readonly")
+        self.model_box.grid(row=2, column=1, **padding)
+        self.model_box["values"] = MODEL_CATALOG[self.vendor_var.get()]
+        self.model_box.current(0)
+
+        ttk.Label(frm, text="Output file:").grid(row=3, column=0, **padding, sticky="e")
+        ttk.Entry(frm, textvariable=self.output_var, width=30).grid(
+            row=3, column=1, **padding
+        )
+        ttk.Button(frm, text="Browse", command=self._select_output).grid(
+            row=3, column=2, **padding
+        )
+
+        ttk.Label(frm, text="Profile config:").grid(
+            row=4, column=0, **padding, sticky="e"
+        )
+        ttk.Entry(frm, textvariable=self.profile_var, width=30).grid(
+            row=4, column=1, **padding
+        )
+        ttk.Button(frm, text="Browse", command=self._select_profile).grid(
+            row=4, column=2, **padding
+        )
+
+        ttk.Button(frm, text="Start Simulation", command=self._start).grid(
+            row=5, column=0, columnspan=3, pady=10
+        )
+
+        ttk.Label(frm, textvariable=self.status_var).grid(
+            row=6, column=0, columnspan=3, **padding
+        )
+
+    # ------------------------------------------------------------------
+    def _on_vendor_change(self, _event: tk.Event | None = None) -> None:
+        models = MODEL_CATALOG.get(self.vendor_var.get(), [])
+        self.model_box["values"] = models
+        if models:
+            self.model_var.set(models[0])
+            self.model_box.current(0)
+
+    # ------------------------------------------------------------------
+    def _select_output(self) -> None:
+        path = filedialog.asksaveasfilename(
+            defaultextension=".xlsx", filetypes=[("Excel", "*.xlsx")]
+        )
+        if path:
+            self.output_var.set(path)
+
+    def _select_profile(self) -> None:
+        path = filedialog.askopenfilename(filetypes=[("JSON", "*.json"), ("All", "*.*")])
+        if path:
+            self.profile_var.set(path)
+
+    def _start(self) -> None:
+        try:
+            count = int(self.participants_var.get())
+        except ValueError:
+            messagebox.showerror("Invalid input", "Participants must be an integer")
+            return
+
+        vendor = self.vendor_var.get().strip()
+        model_name = self.model_var.get().strip()
+        model = f"{vendor}/{model_name}" if vendor else model_name
+        output = Path(self.output_var.get().strip()) if self.output_var.get().strip() else None
+        profile = (
+            Path(self.profile_var.get().strip()) if self.profile_var.get().strip() else None
+        )
+
+        self.status_var.set("Running...")
+        self.after(100, lambda: self._run_simulation(count, model, output, profile))
+
+    def _run_simulation(
+        self, count: int, model: str, output: Path | None, profile: Path | None
+    ) -> None:
+        def task() -> None:
+            try:
+                result = simulate_participants(count, model, output, profile)
+            except Exception as exc:  # pragma: no cover - GUI feedback
+                self.status_var.set("Error")
+                messagebox.showerror("Simulation failed", str(exc))
+            else:
+                self.status_var.set(f"Done: {result}")
+                messagebox.showinfo("Simulation complete", f"Results saved to {result}")
+
+        threading.Thread(target=task, daemon=True).start()
+
+
+def main() -> None:  # pragma: no cover - manual invocation
+    app = SimulatorGUI()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pythonProject/simulate.py
+++ b/pythonProject/simulate.py
@@ -1,8 +1,8 @@
 """Simulate experimental participants using a language model.
 
 This script uses the `litellm` package to generate responses that mimic
-human participants under different experimental conditions.  It can be run
-as a command‑line tool where the number of synthetic participants and other
+human participants under different experimental conditions. It can be run
+as a command-line tool where the number of synthetic participants and other
 parameters are configurable.
 """
 
@@ -27,6 +27,7 @@ from litellm import completion
 
 BASE_DIR = Path(__file__).resolve().parent
 
+
 def load_profile_config(path: Path | None) -> tuple[dict, dict[str, str]]:
     """Load demographic options and trait descriptions from JSON.
 
@@ -46,35 +47,17 @@ def load_profile_config(path: Path | None) -> tuple[dict, dict[str, str]]:
         data = json.load(fh)
     demographics = data.get("demographics", {})
     traits = data.get("characteristics", {})
-=======
-def load_profile_config(path: Path | None) -> tuple[dict, list[str] | None]:
-    """Load optional profile configuration from JSON."""
-    if path is None:
-        return {}, None
-    with path.open("r", encoding="utf-8") as fh:
-        data = json.load(fh)
-    demographics = data.get("demographics", {})
-    traits = data.get("characteristics")
-    
     return demographics, traits
 
 
 def generate_participant_details(
     demographics_options: dict | None = None,
-
     traits: dict[str, str] | None = None,
 ) -> tuple[dict, dict[str, int]]:
     """Return random demographic and trait information."""
 
     demographics_options = demographics_options or {}
     age_range = tuple(demographics_options.get("age_range", (18, 65)))
-=======
-    traits: list[str] | None = None,
-) -> tuple[dict, dict]:
-    """Return random demographic and trait information."""
-
-    demographics_options = demographics_options or {}
-    age_range = demographics_options.get("age_range", (18, 65))
     age = random.randint(*age_range)
     sex = random.choice(demographics_options.get("sex", ["male", "female"]))
     culture_background = random.choice(
@@ -107,40 +90,7 @@ def generate_participant_details(
     ]
     characteristics = {trait: random.randint(1, 7) for trait in trait_names}
     return demographics, characteristics
-=======
 
-    demographics = {
-        "Age": age,
-        "Sex": sex,
-        "Culture Background": culture_background,
-    }
-
-    traits = traits or [
-        "extraversion",
-        "agreeableness",
-        "conscientiousness",
-        "neuroticism",
-        "openness",
-    ]
-    characteristics = {trait: random.randint(1, 7) for trait in traits}
-    return demographics, characteristics
-
-def load_condition(file_path: Path) -> list[dict]:
-    """Return message parts for a condition, supporting text and images."""
-
-    suffix = file_path.suffix.lower()
-    if suffix == ".txt":
-        text = file_path.read_text(encoding="utf-8").strip()
-        return [{"type": "text", "text": text}]
-    if suffix in {".png", ".jpg", ".jpeg", ".gif"}:
-        with file_path.open("rb") as fh:
-            b64 = base64.b64encode(fh.read()).decode("ascii")
-        mime = "jpeg" if suffix in {".jpg", ".jpeg"} else suffix.lstrip(".")
-        url = f"data:image/{mime};base64,{b64}"
-        return [{"type": "image_url", "image_url": {"url": url}}]
-    raise ValueError(f"Unsupported condition file type: {file_path}")
-
-=======
 
 def load_condition(file_path: Path) -> list[dict]:
     """Return message parts for a condition, supporting text and images."""
@@ -163,9 +113,6 @@ def build_messages(
     demographics_options: dict | None = None,
     traits: dict[str, str] | None = None,
 ) -> tuple[list[dict], dict[str, int]]:
-=======
-    traits: list[str] | None = None,
-) -> tuple[list[dict], dict]:
     """Create messages for the language model and participant metadata."""
 
     demographics, characteristics = generate_participant_details(
@@ -184,10 +131,6 @@ def build_messages(
             traits.get(trait, "1=very low, 7=very high") if traits else "1=very low, 7=very high"
         )
         system_prompt += f" Your {trait} is {value} ({meaning})."
-=======
-        system_prompt += (
-            f" Your {trait} is {value} (1=very low, 7=very high)."
-        )
 
     messages = [
         {"role": "system", "content": system_prompt},
@@ -225,12 +168,11 @@ def simulate_participants(
     model:
         Model identifier understood by `litellm`.
     output:
-        Optional path to the Excel file.  If omitted, a timestamped file is
+        Optional path to the Excel file. If omitted, a timestamped file is
         created in the current directory.
     profile_config:
         Optional JSON file describing demographic choices and trait descriptions.
-=======
-        Optional JSON file describing demographic choices and trait names.
+
     Returns
     -------
     Path
@@ -244,8 +186,6 @@ def simulate_participants(
             "LITELLM_API_KEY not set. Create a .env file or export the variable before running."
         )
     demo_options, trait_defs = load_profile_config(profile_config)
-=======
-    demo_options, trait_names = load_profile_config(profile_config)
 
     condition_a = load_condition(BASE_DIR / "conditionA.txt")
     condition_b = load_condition(BASE_DIR / "conditionB.txt")
@@ -259,8 +199,6 @@ def simulate_participants(
             )
             messages, metadata = build_messages(
                 condition_content, demo_options, trait_defs
-=======
-                condition_content, demo_options, trait_names
             )
 
             response = completion(
@@ -317,8 +255,6 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=BASE_DIR / "profile_config.json",
         help="JSON file with demographic options and trait descriptions",
-=======
-        help="JSON file with demographic options and trait names",
     )
     return parser.parse_args()
 
@@ -333,3 +269,4 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover - direct execution
     main()
+


### PR DESCRIPTION
## Summary
- add catalog of model providers and names for the GUI
- allow selecting provider/model via dropdowns and build model string accordingly
- document the new provider/model selection in the README

## Testing
- `python -m py_compile pythonProject/simulate.py pythonProject/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6890a6092c6083308a5cd7a8f30c66ad