### PR TITLE
Remove duplicate tkinter import

### DIFF
--- a/pythonProject/app.py
+++ b/pythonProject/app.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import json
-from tkinter import ttk
 
 # ---------------------------------------------------------------------------
 # Design tokens (subset)


### PR DESCRIPTION
## Summary
- tidy imports in `pythonProject/app.py` by removing redundant `from tkinter import ttk` line

## Testing
- `python -m py_compile pythonProject/app.py` *(fails: SyntaxError '(' was never closed)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68981f28ca58833092580e90cdbf91fc