### PR TITLE
Load trait config and support dynamic ranges

### DIFF
--- a/pythonProject/profile_config.example.json
+++ b/pythonProject/profile_config.example.json
@@ -17,6 +17,7 @@
     "agreeableness": "1=very disagreeable, 7=very agreeable",
     "conscientiousness": "1=very disorganized, 7=very organized",
     "neuroticism": "1=very calm, 7=very anxious",
-    "openness": "1=very traditional, 7=very open-minded"
+    "openness": "1=very traditional, 7=very open-minded",
+    "VariableA": "1=low, 7=high"
   }
 }


### PR DESCRIPTION
## Summary
- build profile form from profile_config traits and read ranges for each trait
- allow simulator to accept trait range tuples and randomize accordingly
- document additional trait example `VariableA`

## Testing
- `python -m py_compile pythonProject/app.py pythonProject/simulate.py`


------
https://chatgpt.com/codex/tasks/task_e_68982429ba988330a2b1f215d774c699