### PR TITLE
Preload condition text in new run dialog

### DIFF
--- a/pythonProject/app.py
+++ b/pythonProject/app.py
@@ -274,6 +274,14 @@ class SimulatorApp(tk.Tk):
             txt = tk.Text(frame, width=40, height=6)
             txt.pack(fill="both", expand=True)
 
+            # Preload default condition text from file if available
+            try:
+                file_path = Path(__file__).with_name(f"condition{label}.txt")
+                txt.insert("1.0", file_path.read_text(encoding="utf-8"))
+            except OSError:
+                # Missing or unreadable file – leave text widget empty
+                pass
+
         ttk.Label(cond, text="Diff (preview) / 差异预览").pack(anchor="w", pady=5)
         tk.Text(cond, height=4).pack(fill="x")
 


### PR DESCRIPTION
## Summary
- Populate Condition A and B text boxes with default content from `conditionA.txt` and `conditionB.txt`
- Handle missing or unreadable condition files gracefully

## Testing
- `pytest`
- `python -m py_compile pythonProject/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68982912091483309e3ebb5407383b96