### PR TITLE
Add model dropdown and GitHub models fetch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ litellm
 pandas
 openpyxl
 python-dotenv
+requests


### PR DESCRIPTION
## Summary
- Add provider-specific model dropdown in app GUI
- Fetch available models via API, including GitHub Models endpoint
- Forward selected provider and model to simulation
- Add `requests` dependency

## Testing
- `python -m py_compile pythonProject/app.py`
- `python - <<'PY'
import requests, os
headers={'X-GitHub-Api-Version':'2022-11-28'}
if os.getenv('GITHUB_TOKEN'):
    headers['Authorization']=f"Bearer {os.getenv('GITHUB_TOKEN')}"
resp=requests.get('https://api.github.com/models', headers=headers)
print('status', resp.status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68983101bff88330805269fa0df04d82