### PR TITLE
Ensure GitHub model fetch uses JSON API

### DIFF
--- a/pythonProject/app.py
+++ b/pythonProject/app.py
@@ -359,7 +359,10 @@ class SimulatorApp(tk.Tk):
         def fetch_models_for_provider(name: str) -> list[str]:
             try:
                 if name == "GitHub":
-                    headers = {"X-GitHub-Api-Version": "2022-11-28"}
+                    headers = {
+                        "X-GitHub-Api-Version": "2022-11-28",
+                        "Accept": "application/vnd.github+json",
+                    }
                     token = os.getenv("GITHUB_TOKEN")
                     if token:
                         headers["Authorization"] = f"Bearer {token}"

--- a/setup.py
+++ b/setup.py
@@ -270,27 +270,27 @@ class SetupWizard:
     def _test_github_models(self) -> bool:
         """Test GitHub Models connection."""
         try:
-            # Test with a simple API call
             token = os.getenv("GITHUB_TOKEN")
             headers = {
                 "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json"
+                "X-GitHub-Api-Version": "2022-11-28",
+                "Accept": "application/vnd.github+json",
             }
-
-            # Test GitHub API access
             response = requests.get(
-                "https://api.github.com/user",
-                headers={"Authorization": f"token {token}"}
+                "https://api.github.com/models", headers=headers, timeout=5
             )
-
             if response.status_code == 200:
-                username = response.json().get("login", "Unknown")
-                print(f"      Connected as: {username}")
+                try:
+                    data = response.json()
+                    count = len(data.get("data", [])) if isinstance(data, dict) else len(data)
+                    print(f"      Retrieved {count} models")
+                except Exception:
+                    print("      Received non-JSON response")
+                    return False
                 return True
             else:
                 print(f"      HTTP {response.status_code}: {response.text}")
                 return False
-
         except Exception as e:
             print(f"      Error: {e}")
             return False


### PR DESCRIPTION
## Summary
- add `Accept: application/vnd.github+json` to GitHub model fetch
- mirror headers in setup's GitHub test to verify JSON response

## Testing
- `python - <<'PY'
import os, requests, json
headers = {"X-GitHub-Api-Version": "2022-11-28", "Accept": "application/vnd.github+json"}
token = os.getenv("GITHUB_TOKEN")
if token:
    headers["Authorization"] = f"Bearer {token}"
resp = requests.get("https://api.github.com/models", headers=headers, timeout=5)
print("Status:", resp.status_code)
print("Content-Type:", resp.headers.get("content-type"))
try:
    data = resp.json()
    print("JSON keys:", list(data)[:5] if isinstance(data, dict) else data[:1])
except Exception as e:
    print("Failed to parse JSON:", e)
    print("Response snippet:", resp.text[:100])
PY`
- `python -m py_compile pythonProject/app.py setup.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898342eac0883308b07a160fb6fec08