### PR TITLE
fix: clean up placeholder GUI methods

### DIFF
--- a/pythonProject/app.py
+++ b/pythonProject/app.py
@@ -231,13 +231,6 @@ class SimulatorApp(tk.Tk):
         ttk.Button(templates, text="Save Template / 保存模板").pack(side="left", padx=2)
         ttk.Button(templates, text="Load Template / 加载模板").pack(side="left", padx=2)
         return frame
-        return Placeholder(master, "Runs / 运行队列")
-
-    def _build_results(self, master: tk.Misc) -> ttk.Frame:
-        return Placeholder(master, "Results / 结果浏览器")
-
-    def _build_config(self, master: tk.Misc) -> ttk.Frame:
-        return Placeholder(master, "Config / 配置与环境")
 
     # ------------------------------------------------------------------
     def _open_new_run(self) -> None:


### PR DESCRIPTION
## Summary
- remove duplicate placeholder builders in `SimulatorApp`
- keep fully implemented ` _build_results` and `_build_config`

## Testing
- `python -m pytest`
- `timeout 5 xvfb-run -a python pythonProject/app.py`

------
https://chatgpt.com/codex/tasks/task_e_689845c1649c8330bb18661a6ae45e33