### PR TITLE
Ensure .env overrides environment variables in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ class SetupWizard:
         print("\nTesting configuration...")
 
         # Load environment variables
-        load_dotenv(self.env_file)
+        load_dotenv(self.env_file, override=True)
 
         # Test available APIs
         tested_any = False


### PR DESCRIPTION
## Summary
- Ensure `load_dotenv` always overrides existing environment variables so `.env` values are used when testing configuration.

## Testing
- `python - <<'PY'
import os
from setup import SetupWizard
w = SetupWizard()
print('Before:', os.getenv('LITELLM_API_KEY'))
w.test_configuration()
print('After:', os.getenv('LITELLM_API_KEY'))
PY`
- `printf 'n\n' | python setup.py`

------
https://chatgpt.com/codex/tasks/task_e_689877d5341083308859a21aea3db977